### PR TITLE
Update HighchartsWidget.php

### DIFF
--- a/highcharts/HighchartsWidget.php
+++ b/highcharts/HighchartsWidget.php
@@ -75,6 +75,7 @@ class HighchartsWidget extends CWidget
 	
 	public $options = array();
 	public $htmlOptions = array();
+	public $setupOptions = array();
 	public $scripts = array();
 
 
@@ -103,7 +104,8 @@ class HighchartsWidget extends CWidget
 		array_unshift($this->scripts, $this->_baseScript);
 
 		$jsOptions = CJavaScript::encode($this->options);
-		$this->registerScripts(__CLASS__ . '#' . $id, "var chart = new Highcharts.{$this->_constr}($jsOptions);");
+		$setupOptions = CJavaScript::encode($this->setupOptions);
+		$this->registerScripts(__CLASS__ . '#' . $id, "Highcharts.setOptions($setupOptions); var chart = new Highcharts.{$this->_constr}($jsOptions);");
 	}
 
 


### PR DESCRIPTION
The 'lang' Option can only be set before the instantion of the object. see: http://api.highcharts.com/highcharts#lang

this change enables you to set the lang property for example with:

``` php
$this->Widget('ext.highcharts.HighchartsWidget', array(
'setupOptions'=> array(
        'lang' => array(
            'decimalPoint' => ',',
            'thousandsSep' => '.',
            'loading' => 'Lade...',
            'months' => Yii::app()->locale->getMonthNames('wide'),
            'weekdays' => Yii::app()->locale->getWeekDayNames('wide'),
            'shortMonths' => Yii::app()->locale->getMonthNames('abbreviated')
        )
    ),
);
```
